### PR TITLE
Handle vendor specific json types in request bodies when converting f…

### DIFF
--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -89,18 +89,20 @@ function convertOperations(openApiSpec) {
 }
 
 function convertParameters(openApiSpec, operation) {
-    var content, param;
+    var content, param, contentKey;
     operation.parameters = operation.parameters || [];
     if (operation.requestBody) {
         param = resolveReference(openApiSpec, operation.requestBody);
         param.name = 'body';
         content = param.content;
         if (content) {
+            contentKey = Object.keys(content)[0];
             delete param.content;
-            if (content['application/x-www-form-urlencoded']) {
-                operation.consumes = ['application/x-www-form-urlencoded'];
+
+            if (contentKey === 'application/x-www-form-urlencoded') {
+                operation.consumes = [contentKey];
                 param.in = 'formData';
-                param.schema = content['application/x-www-form-urlencoded'].schema;
+                param.schema = content[contentKey].schema;
                 param.schema = resolveReference(openApiSpec, param.schema);
                 if (param.schema.type === 'object' && param.schema.properties) {
                     for (var name in param.schema.properties) {
@@ -112,22 +114,22 @@ function convertParameters(openApiSpec, operation) {
                 } else {
                     operation.parameters.push(param);
                 }
-            } else if (content['multipart/form-data']) {
-                operation.consumes = ['multipart/form-data'];
+            } else if (contentKey === 'multipart/form-data') {
+                operation.consumes = [contentKey];
                 param.in = 'formData';
-                param.schema = content['multipart/form-data'].schema;
+                param.schema = content[contentKey].schema;
                 operation.parameters.push(param);
-            } else if (content['application/octet-stream']) {
-                operation.consumes = ['application/octet-stream'];
+            } else if (contentKey === 'application/octet-stream') {
+                operation.consumes = [contentKey];
                 param.in = 'formData';
                 param.type = 'file';
                 param.name = param.name || 'file';
                 delete param.schema;
                 operation.parameters.push(param);
-            } else if (content['application/json']) {
-                operation.consumes = ['application/json'];
+            } else if (isJsonMimeType(contentKey)) {
+                operation.consumes = [contentKey];
                 param.in = 'body';
-                param.schema = content['application/json'].schema;
+                param.schema = content[contentKey].schema;
                 operation.parameters.push(param);
             } else {
                 console.warn('unsupported request body media type', operation.operationId, content);
@@ -221,3 +223,8 @@ function convertSecurityDefinitions(openApiSpec) {
     delete openApiSpec.components.securitySchemes;
 }
 
+function isJsonMimeType(type) {
+    var jsonMimeTypeRegex = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/
+    var regexp = new RegExp(jsonMimeTypeRegex, 'i')
+    return regexp.test(type);
+}

--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -8,7 +8,7 @@ var APPLICATION_JSON_REGEX = /^(application\/json|[^;\/ \t]+\/[^;\/ \t]+[+]json)
 var SUPPORTED_MIME_TYPES = {
     APPLICATION_X_WWW_URLENCODED: 'application/x-www-form-urlencoded',
     MUTIPLART_FORM_DATA: 'multipart/form-data',
-    APPLICATION_OCTET_STREAM: 'application/octet-stream',
+    APPLICATION_OCTET_STREAM: 'application/octet-stream'
 };
 
 var urlParser = require('url');
@@ -235,7 +235,8 @@ function isJsonMimeType(type) {
 }
 
 function getSupportedMimeTypes(content) {
+    var MIME_VALUES = Object.keys(SUPPORTED_MIME_TYPES).map((key) => { return SUPPORTED_MIME_TYPES[key] });
     return Object.keys(content).filter(key => {
-        return Object.values(SUPPORTED_MIME_TYPES).indexOf(key) > -1 || isJsonMimeType(key);
+        return MIME_VALUES.indexOf(key) > -1 || isJsonMimeType(key);
     });
 }

--- a/lib/converters/openapi3_to_swagger2.js
+++ b/lib/converters/openapi3_to_swagger2.js
@@ -4,6 +4,13 @@ var HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 
     SCHEMA_PROPERTIES = ['format', 'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', 'minLength', 'maxLength', 'multipleOf', 'minItems', 'maxItems', 'uniqueItems', 'minProperties', 'maxProperties', 'additionalProperties', 'pattern', 'enum', 'default'],
     ARRAY_PROPERTIES = ['type', 'items'];
 
+var APPLICATION_JSON_REGEX = /^(application\/json|[^;\/ \t]+\/[^;\/ \t]+[+]json)[ \t]*(;.*)?$/;
+var SUPPORTED_MIME_TYPES = {
+    APPLICATION_X_WWW_URLENCODED: 'application/x-www-form-urlencoded',
+    MUTIPLART_FORM_DATA: 'multipart/form-data',
+    APPLICATION_OCTET_STREAM: 'application/octet-stream',
+};
+
 var urlParser = require('url');
 
 /**
@@ -96,10 +103,10 @@ function convertParameters(openApiSpec, operation) {
         param.name = 'body';
         content = param.content;
         if (content) {
-            contentKey = Object.keys(content)[0];
+            contentKey = getSupportedMimeTypes(content)[0];
             delete param.content;
 
-            if (contentKey === 'application/x-www-form-urlencoded') {
+            if (contentKey === SUPPORTED_MIME_TYPES.APPLICATION_X_WWW_URLENCODED) {
                 operation.consumes = [contentKey];
                 param.in = 'formData';
                 param.schema = content[contentKey].schema;
@@ -114,12 +121,12 @@ function convertParameters(openApiSpec, operation) {
                 } else {
                     operation.parameters.push(param);
                 }
-            } else if (contentKey === 'multipart/form-data') {
+            } else if (contentKey === SUPPORTED_MIME_TYPES.MUTIPLART_FORM_DATA) {
                 operation.consumes = [contentKey];
                 param.in = 'formData';
                 param.schema = content[contentKey].schema;
                 operation.parameters.push(param);
-            } else if (contentKey === 'application/octet-stream') {
+            } else if (contentKey === SUPPORTED_MIME_TYPES.APPLICATION_OCTET_STREAM) {
                 operation.consumes = [contentKey];
                 param.in = 'formData';
                 param.type = 'file';
@@ -224,7 +231,11 @@ function convertSecurityDefinitions(openApiSpec) {
 }
 
 function isJsonMimeType(type) {
-    var jsonMimeTypeRegex = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/
-    var regexp = new RegExp(jsonMimeTypeRegex, 'i')
-    return regexp.test(type);
+    return new RegExp(APPLICATION_JSON_REGEX, 'i').test(type);
+}
+
+function getSupportedMimeTypes(content) {
+    return Object.keys(content).filter(key => {
+        return Object.values(SUPPORTED_MIME_TYPES).indexOf(key) > -1 || isJsonMimeType(key);
+    });
 }

--- a/test/input/openapi_3/petstore.json
+++ b/test/input/openapi_3/petstore.json
@@ -237,7 +237,7 @@
         "operationId": "updatePet",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/vnd.api+json": {
               "schema": {
                 "$ref": "#/components/schemas/Pet"
               }

--- a/test/input/openapi_3/petstore.json
+++ b/test/input/openapi_3/petstore.json
@@ -552,12 +552,12 @@
         ],
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/xml": {
               "schema": {
                 "$ref": "#/components/schemas/Pet"
               }
             },
-            "application/xml": {
+            "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/Pet"
               }

--- a/test/output/openapi_3/petstore_from_oas3.json
+++ b/test/output/openapi_3/petstore_from_oas3.json
@@ -237,7 +237,7 @@
         "operationId": "updatePet",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/vnd.api+json": {
               "schema": {
                 "$ref": "#/components/schemas/Pet"
               }

--- a/test/output/swagger_2/petstore_from_oas3.json
+++ b/test/output/swagger_2/petstore_from_oas3.json
@@ -191,7 +191,7 @@
     "/pet": {
       "put": {
         "consumes": [
-          "application/json"
+          "application/vnd.api+json"
         ],
         "operationId": "updatePet",
         "parameters": [


### PR DESCRIPTION
- Modify the petstore test caste to include a the application/vnd.api+json both in one request and in one reponse
- Match JSON types and pass them along in the consumes array when converting to swagger2